### PR TITLE
feat(commands): add slash command implementation for id command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "modmail_rs",
+  "name": "rustmail",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/commands/id.rs
+++ b/src/commands/id.rs
@@ -1,49 +1,73 @@
 use crate::config::Config;
 use crate::db::get_thread_by_channel_id;
-use crate::db::threads::is_a_ticket_channel;
+use crate::db::operations::threads::is_a_ticket_channel;
 use crate::errors::ThreadError::NotAThreadChannel;
 use crate::errors::common::{database_connection_failed, thread_not_found};
 use crate::errors::{ModmailError, ModmailResult};
 use crate::utils::message::message_builder::MessageBuilder;
-use serenity::all::{CommandInteraction, CommandOptionType, Context, CreateCommand, CreateCommandOption, Message, ResolvedOption, ResolvedValue};
+use serenity::all::{CommandInteraction, Context, CreateCommand, Message, ResolvedOption};
 use crate::i18n::get_translated_message;
 
 pub fn register() -> CreateCommand {
-    CreateCommand::new("id").description("Get ID of the user in the thread").add_option(
-        CreateCommandOption::new(CommandOptionType::User, "id", "The ID of the user")
-            .required(true),
-    )
+    CreateCommand::new("id").description("Get ID of the user in the thread")
 }
 
-pub async fn run(command: CommandInteraction, options: &[ResolvedOption<'_>], config: &Config) -> String {
+pub async fn run(command: &CommandInteraction, _options: &[ResolvedOption<'_>], config: &Config) -> String {
     let pool = match &config.db_pool {
         Some(pool) => pool,
         None => {
-            eprintln!("Database pool is not set in config.");
-            return None
+            return get_translated_message(
+                config,
+                "database.connection_failed",
+                None,
+                Some(command.user.id),
+                command.guild_id.map(|g| g.get()),
+                None,
+            )
+            .await;
         }
     };
 
-    if is_a_ticket_channel(command.channel_id, &pool).await {
-        let thread = match get_thread_by_channel_id(&command.channel_id.to_string(), pool).await {
-            Some(thread) => thread,
-            None => return,
-        };
-
-        if let Some(ResolvedOption {
-                    value: ResolvedValue::User(user, _), ..
-                }) = options.first()
-        {
-            let mut params = std::collections::HashMap::new();
-            params.insert("user".to_string(), format!("<@{}>", thread.user_id));
-            params.insert(
-                "id".to_string(),
-                format!("||{}||", thread.user_id.to_string()),
-            );
-
-            get_translated_message(&config, "id.show_id", Some(&params), None, None, None).await
-        }
+    if !is_a_ticket_channel(command.channel_id, pool).await {
+        return get_translated_message(
+            config,
+            "thread.not_a_thread_channel",
+            None,
+            Some(command.user.id),
+            command.guild_id.map(|g| g.get()),
+            None,
+        )
+        .await;
     }
+
+    let thread = match get_thread_by_channel_id(&command.channel_id.to_string(), pool).await {
+        Some(thread) => thread,
+        None => {
+            return get_translated_message(
+                config,
+                "thread.not_found",
+                None,
+                Some(command.user.id),
+                command.guild_id.map(|g| g.get()),
+                None,
+            )
+            .await;
+        }
+    };
+
+    let mut params = std::collections::HashMap::new();
+    params.insert("user".to_string(), format!("<@{}>", thread.user_id));
+    params.insert("id".to_string(), format!("||{}||", thread.user_id.to_string()));
+
+    get_translated_message(
+        config,
+        "id.show_id",
+        Some(&params),
+        Some(command.user.id),
+        command.guild_id.map(|g| g.get()),
+        None,
+    )
+    .await
 }
 
 pub async fn id(ctx: &Context, msg: &Message, config: &Config) -> ModmailResult<()> {

--- a/src/handlers/guild_interaction_handler.rs
+++ b/src/handlers/guild_interaction_handler.rs
@@ -45,16 +45,23 @@ impl EventHandler for InteractionHandler {
                     return;
                 }
             }
-            Interaction::Command(mut command) => {
-                let content = match command.data.name.as_str() {
-                    "id" => {
-                        return;
-                    },
+            Interaction::Command(command) => {
+                let content: String = match command.data.name.as_str() {
+                    "id" => commands::id::run(&command, &command.data.options(), &self.config).await,
                     _ => {
                         println!("Command not implemented: {}", command.data.name);
                         return;
                     },
                 };
+
+                let response = CreateInteractionResponse::Message(
+                    MessageBuilder::system_message(&ctx, &self.config)
+                        .content(content)
+                        .to_channel(command.channel_id)
+                        .build_interaction_message()
+                        .await,
+                );
+                let _ = command.create_response(&ctx.http, response).await;
             }
             _ => {}
         }


### PR DESCRIPTION
This pull request refactors the handling of the `/id` command and improves error messaging and user feedback. The main changes are in how the command is registered, executed, and responded to, making the code more robust and user-friendly.

### Command handling and response improvements

* The `/id` command now sends a translated message back to the user, including error messages if the command is used outside a thread channel or if the thread is not found. Previously, the command did not respond to the user in these cases. [[1]](diffhunk://#diff-c1dcc919406384abe34f07d35200ac7dd4dd40a4939d5f9a9e4d1b9599252fb8L3-R70) [[2]](diffhunk://#diff-8c4af5ed33cf2d7da7be0fae385e92aa8c15954534701e22cd9d244e5191dc14L48-R64)
* The command handler for interactions now calls the `id::run` function and sends its output as a system message response in Discord, ensuring consistent feedback for all command outcomes.

### Codebase cleanup and refactoring

* Removed unnecessary command options from the `/id` command registration, simplifying its interface.
* Updated imports to use the correct module path for `is_a_ticket_channel`, improving code organization.
* Refactored function signatures and removed unused parameters for clarity and maintainability.