### PR TITLE
feat(commands): add slash command implementation for move command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.3",
@@ -1919,9 +1919,19 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
 dependencies = [
  "serde_derive",
 ]
@@ -1937,9 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1960,11 +1970,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2660,12 +2670,12 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+checksum = "00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
@@ -2675,27 +2685,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "d163a63c116ce562a22cda521fcc4d79152e7aba014456fb5eb442f6d6a10109"
 
 [[package]]
 name = "tower"
@@ -3343,9 +3353,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ serde = { version = "*", features = ["derive"] }
 serenity = "0.12.4"
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "sqlite", "macros", "migrate"] }
 tokio = { version = "1.47.1", features = ["rt-multi-thread"] }
-toml = "0.9.5"
+toml = "0.9.7"
 reqwest = "0.12.23"
 async-trait = "0.1.89"
 chrono = { version = "0.4.42", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
 A Discord modmail bot written in Rust that allows staff to manage support tickets via channels, with features like message editing, internationalization, structured error handling, and more.
 The bot can operate in single-server or dual-server modes, supports SQLite for data storage, and offers a range of commands for staff to interact with users efficiently.
 
+Slash commands are currently under development and will be available soon! See [this](https://github.com/Akinator31/rustmail/tree/convert_to_slash_commands)
+
+
 ---
 ## ⚠️ Warning ⚠️
 This is my first major project in Rust; while I have solid experience in C and other languages, I'm learning Rust as I go — feedback and PRs are welcome.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,16 +5,16 @@
   "packages": {
     "": {
       "dependencies": {
-        "@prisma/client": "^6.16.1"
+        "@prisma/client": "^6.16.2"
       },
       "devDependencies": {
-        "prisma": "^6.16.1"
+        "prisma": "^6.16.2"
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.16.1.tgz",
-      "integrity": "sha512-QaBCOY29lLAxEFFJgBPyW3WInCW52fJeQTmWx/h6YsP5u0bwuqP51aP0uhqFvhK9DaZPwvai/M4tSDYLVE9vRg==",
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.16.2.tgz",
+      "integrity": "sha512-E00PxBcalMfYO/TWnXobBVUai6eW/g5OsifWQsQDzJYm7yaY+IRLo7ZLsaefi0QkTpxfuhFcQ/w180i6kX3iJw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.16.1.tgz",
-      "integrity": "sha512-sz3uxRPNL62QrJ0EYiujCFkIGZ3hg+9hgC1Ae1HjoYuj0BxCqHua4JNijYvYCrh9LlofZDZcRBX3tHBfLvAngA==",
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.16.2.tgz",
+      "integrity": "sha512-mKXSUrcqXj0LXWPmJsK2s3p9PN+aoAbyMx7m5E1v1FufofR1ZpPoIArjjzOIm+bJRLLvYftoNYLx1tbHgF9/yg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -47,24 +47,24 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.16.1.tgz",
-      "integrity": "sha512-RWv/VisW5vJE4cDRTuAHeVedtGoItXTnhuLHsSlJ9202QKz60uiXWywBlVcqXVq8bFeIZoCoWH+R1duZJPwqLw==",
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.16.2.tgz",
+      "integrity": "sha512-bo4/gA/HVV6u8YK2uY6glhNsJ7r+k/i5iQ9ny/3q5bt9ijCj7WMPUwfTKPvtEgLP+/r26Z686ly11hhcLiQ8zA==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.16.1.tgz",
-      "integrity": "sha512-EOnEM5HlosPudBqbI+jipmaW/vQEaF0bKBo4gVkGabasINHR6RpC6h44fKZEqx4GD8CvH+einD2+b49DQrwrAg==",
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.16.2.tgz",
+      "integrity": "sha512-7yf3AjfPUgsg/l7JSu1iEhsmZZ/YE00yURPjTikqm2z4btM0bCl2coFtTGfeSOWbQMmq45Jab+53yGUIAT1sjA==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.16.1",
+        "@prisma/debug": "6.16.2",
         "@prisma/engines-version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
-        "@prisma/fetch-engine": "6.16.1",
-        "@prisma/get-platform": "6.16.1"
+        "@prisma/fetch-engine": "6.16.2",
+        "@prisma/get-platform": "6.16.2"
       }
     },
     "node_modules/@prisma/engines-version": {
@@ -75,25 +75,25 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.16.1.tgz",
-      "integrity": "sha512-fl/PKQ8da5YTayw86WD3O9OmKJEM43gD3vANy2hS5S1CnfW2oPXk+Q03+gUWqcKK306QqhjjIHRFuTZ31WaosQ==",
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.16.2.tgz",
+      "integrity": "sha512-wPnZ8DMRqpgzye758ZvfAMiNJRuYpz+rhgEBZi60ZqDIgOU2694oJxiuu3GKFeYeR/hXxso4/2oBC243t/whxQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.16.1",
+        "@prisma/debug": "6.16.2",
         "@prisma/engines-version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
-        "@prisma/get-platform": "6.16.1"
+        "@prisma/get-platform": "6.16.2"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.16.1.tgz",
-      "integrity": "sha512-kUfg4vagBG7dnaGRcGd1c0ytQFcDj2SUABiuveIpL3bthFdTLI6PJeLEia6Q8Dgh+WhPdo0N2q0Fzjk63XTyaA==",
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.16.2.tgz",
+      "integrity": "sha512-U/P36Uke5wS7r1+omtAgJpEB94tlT4SdlgaeTc6HVTTT93pXj7zZ+B/cZnmnvjcNPfWddgoDx8RLjmQwqGDYyA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.16.1"
+        "@prisma/debug": "6.16.2"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -299,16 +299,16 @@
       "license": "MIT"
     },
     "node_modules/nypm": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.1.tgz",
-      "integrity": "sha512-hlacBiRiv1k9hZFiphPUkfSQ/ZfQzZDzC+8z0wL3lvDAOUu/2NnChkKuMoMjNur/9OpKuz2QsIeiPVN0xM5Q0w==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
+      "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.1.6",
         "consola": "^3.4.2",
         "pathe": "^2.0.3",
-        "pkg-types": "^2.2.0",
+        "pkg-types": "^2.3.0",
         "tinyexec": "^1.0.1"
       },
       "bin": {
@@ -352,15 +352,15 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.16.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.16.1.tgz",
-      "integrity": "sha512-MFkMU0eaDDKAT4R/By2IA9oQmwLTxokqv2wegAErr9Rf+oIe7W2sYpE/Uxq0H2DliIR7vnV63PkC1bEwUtl98w==",
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.16.2.tgz",
+      "integrity": "sha512-aRvldGE5UUJTtVmFiH3WfNFNiqFlAtePUxcI0UEGlnXCX7DqhiMT5TRYwncHFeA/Reca5W6ToXXyCMTeFPdSXA==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.16.1",
-        "@prisma/engines": "6.16.1"
+        "@prisma/config": "6.16.2",
+        "@prisma/engines": "6.16.2"
       },
       "bin": {
         "prisma": "build/index.js"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "devDependencies": {
-    "prisma": "^6.16.1"
+    "prisma": "^6.16.2"
   },
   "dependencies": {
-    "@prisma/client": "^6.16.1"
+    "@prisma/client": "^6.16.2"
   }
 }

--- a/src/commands/id.rs
+++ b/src/commands/id.rs
@@ -12,7 +12,7 @@ pub fn register() -> CreateCommand {
     CreateCommand::new("id").description("Get ID of the user in the thread")
 }
 
-pub async fn run(command: &CommandInteraction, _options: &[ResolvedOption<'_>], config: &Config) -> String {
+pub async fn run(_ctx: &Context, command: &CommandInteraction, _options: &[ResolvedOption<'_>], config: &Config) -> String {
     let pool = match &config.db_pool {
         Some(pool) => pool,
         None => {

--- a/src/commands/move_thread.rs
+++ b/src/commands/move_thread.rs
@@ -3,8 +3,19 @@ use crate::db::operations::get_user_id_from_channel_id;
 use crate::errors::{ModmailResult, common};
 use crate::i18n::get_translated_message;
 use crate::utils::message::message_builder::MessageBuilder;
-use serenity::all::{ChannelId, Context, EditChannel, GuildId, Message};
+use serenity::all::{ChannelId, CommandInteraction, CommandOptionType, Context, CreateCommand, CreateCommandOption, EditChannel, GuildId, Message, ResolvedOption};
 use std::collections::HashMap;
+
+pub fn register() -> CreateCommand {
+    CreateCommand::new("move").description("Move a thread in an other category").add_option(
+        CreateCommandOption::new(CommandOptionType::String, "category", "The category where you want to move the thread")
+            .required(true)
+    )
+}
+
+pub async fn run(command: &CommandInteraction, _options: &[ResolvedOption<'_>], config: &Config) -> String {
+    "in progress".to_string()
+}
 
 pub async fn move_thread(ctx: &Context, msg: &Message, config: &Config) -> ModmailResult<()> {
     let pool = config

--- a/src/handlers/guild_interaction_handler.rs
+++ b/src/handlers/guild_interaction_handler.rs
@@ -48,6 +48,7 @@ impl EventHandler for InteractionHandler {
             Interaction::Command(command) => {
                 let content: String = match command.data.name.as_str() {
                     "id" => commands::id::run(&command, &command.data.options(), &self.config).await,
+                    "move" => commands::move_thread::run(&command, &command.data.options(), &self.config).await,
                     _ => {
                         println!("Command not implemented: {}", command.data.name);
                         return;

--- a/src/handlers/guild_interaction_handler.rs
+++ b/src/handlers/guild_interaction_handler.rs
@@ -47,8 +47,8 @@ impl EventHandler for InteractionHandler {
             }
             Interaction::Command(command) => {
                 let content: String = match command.data.name.as_str() {
-                    "id" => commands::id::run(&command, &command.data.options(), &self.config).await,
-                    "move" => commands::move_thread::run(&command, &command.data.options(), &self.config).await,
+                    "id" => commands::id::run(&ctx, &command, &command.data.options(), &self.config).await,
+                    "move" => commands::move_thread::run(&ctx, &command, &command.data.options(), &self.config).await,
                     _ => {
                         println!("Command not implemented: {}", command.data.name);
                         return;

--- a/src/handlers/ready_handler.rs
+++ b/src/handlers/ready_handler.rs
@@ -43,6 +43,7 @@ impl EventHandler for ReadyHandler {
 
         let commands = guild_id.set_commands(&ctx.http, vec![
             commands::id::register(),
+            commands::move_thread::register(),
         ]).await;
 
         println!("I now have the following guild slash commands: {commands:#?}");


### PR DESCRIPTION
This pull request adds support for Discord slash commands for the `id` and `move` thread functionalities, refactoring the codebase to enable command registration, execution, and response handling. The changes include new handler logic for slash commands, registration of commands on bot startup, and refactoring of thread-moving helpers for both message-based and command-based invocations.

**Slash Command Integration**
* Added slash command registration for `id` and `move` commands during bot startup in `ReadyHandler`, making these commands available in the guild.
* Implemented slash command execution logic in `InteractionHandler`, routing incoming commands to the appropriate handlers and sending responses.

**Command Handler Refactoring**
* Added `register` and `run` functions to both `id` and `move_thread` modules, allowing them to handle slash command invocations and generate appropriate responses. [[1]](diffhunk://#diff-c1dcc919406384abe34f07d35200ac7dd4dd40a4939d5f9a9e4d1b9599252fb8L3-R71) [[2]](diffhunk://#diff-8b431e841296bf68b8ad51192a7ffaa29cd517ae33b8fad8f2cc5f2b1fc5f14eL6-R121)
* Refactored thread-moving logic to support both message-based (`move_channel_to_category_by_msg`) and command-based (`move_channel_to_category_by_command_option`) invocations, improving code organization and reusability. [[1]](diffhunk://#diff-8b431e841296bf68b8ad51192a7ffaa29cd517ae33b8fad8f2cc5f2b1fc5f14eL36-R149) [[2]](diffhunk://#diff-8b431e841296bf68b8ad51192a7ffaa29cd517ae33b8fad8f2cc5f2b1fc5f14eL94-R207) [[3]](diffhunk://#diff-8b431e841296bf68b8ad51192a7ffaa29cd517ae33b8fad8f2cc5f2b1fc5f14eR217-R226)

**Imports and Internal Structure**
* Updated imports throughout the codebase to support new command handler functions and reorganized modules for clarity. [[1]](diffhunk://#diff-8c4af5ed33cf2d7da7be0fae385e92aa8c15954534701e22cd9d244e5191dc14R10) [[2]](diffhunk://#diff-6dd0a5f3db7dd9b1d95252177f090d2647a1a1a47938f9cad7abbabc378a1b09L5-R10)